### PR TITLE
use explicit import lists for System.Enviroment 

### DIFF
--- a/src/Options.hs
+++ b/src/Options.hs
@@ -37,7 +37,7 @@ import Data.Maybe
 import System.Console.GetOpt
 import System.Directory
 import System.IO.Unsafe
-import System.Environment
+import System.Environment (getArgs, getProgName)
 import System.Exit
 import qualified Data.ByteString.UTF8 as BS
 import qualified Data.Map as M


### PR DESCRIPTION
In recent versions of System.Environment there is a lookupEnv function which conflicts with the lookupEnv that ajhc provides. I added some explicit import lists for System.Environment to avoid the conflicting function definitions.
