### PR TITLE
Fix GC: don't increment megablock count, when re-use the megablock in free list

### DIFF
--- a/rts/rts/gc_jgc.c
+++ b/rts/rts/gc_jgc.c
@@ -410,17 +410,17 @@ s_new_megablock(arena_t arena)
                 SLIST_REMOVE(&free_megablocks, mb, s_megablock, next);
         } else {
                 mb = malloc(sizeof(*mb));
-        }
 #ifdef _JHC_JGC_LIMITED_NUM_MEGABLOCK
-        static int count = 0;
-        if (count >= _JHC_JGC_LIMITED_NUM_MEGABLOCK) {
-                abort();
-        }
-        mb->base = aligned_megablock + (MEGABLOCK_SIZE) * count;
-        count++;
+                static int count = 0;
+                if (count >= _JHC_JGC_LIMITED_NUM_MEGABLOCK) {
+                  abort();
+                }
+                mb->base = aligned_megablock + (MEGABLOCK_SIZE) * count;
+                count++;
 #else
-        mb->base = jhc_aligned_alloc(MEGABLOCK_SIZE);
+                mb->base = jhc_aligned_alloc(MEGABLOCK_SIZE);
 #endif
+        }
         jhc_rts_unlock();
 
         VALGRIND_MAKE_MEM_NOACCESS(mb->base,MEGABLOCK_SIZE);


### PR DESCRIPTION
The problem is caused, when `_JHC_JGC_LIMITED_NUM_MEGABLOCK` is enabled.

The heavy-memory-use program call `s_new_megablock` via `s_alloc`. Because `s_new_megablock` has free list, this does'nt always cause a lack of memory.

But `s_new_megablock` is increment mega block count on each call. So, we reach to limit before a lack of memory.
